### PR TITLE
Fixes #68: Raspberry pi should always be correctly detected

### DIFF
--- a/bumblebee/hive.py
+++ b/bumblebee/hive.py
@@ -225,7 +225,7 @@ def determineOS():
   if sys.platform.startswith('darwin'):
     return "osx"
   elif sys.platform.startswith('linux'):
-    if os.uname()[1].startswith('raspberrypi'):
+    if os.uname()[4].startswith('arm'):
       return "raspberrypi"
     else:
       return "linux"


### PR DESCRIPTION
Unless of course they no longer use an arm device.
